### PR TITLE
Add auto-updating visualization to Streamlit app

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,5 +23,6 @@ streamlit run src/streamlit_app.py
 ```
 
 Use the sidebar to tweak dataset generation parameters and the number of
-neighbors used in the KNN classifier. The app displays the resulting metrics and
-classification report.
+neighbors used in the KNN classifier. Results are updated automatically when
+parameters change and a confusion matrix visualization is displayed alongside the
+metrics and classification report.

--- a/src/knn_risk_classifier.py
+++ b/src/knn_risk_classifier.py
@@ -69,6 +69,12 @@ def train_knn(df, n_neighbors=3):
         Dataset with features and ``Risk Classification`` column.
     n_neighbors : int, optional
         Number of neighbours for ``KNeighborsClassifier``.
+
+    Returns
+    -------
+    tuple
+        Tuple containing metrics dictionary, classification report
+        ``pandas.DataFrame`` and a confusion matrix ``pandas.DataFrame``.
     """
     X = df.drop(columns=["Risk Classification"])
     y = df["Risk Classification"]
@@ -90,12 +96,18 @@ def train_knn(df, n_neighbors=3):
     }
 
     report = classification_report(y_test, y_pred, output_dict=True)
-    return metrics, pd.DataFrame(report).transpose()
+
+    labels = sorted(y.unique())
+    cm = confusion_matrix(y_test, y_pred, labels=labels)
+    cm_df = pd.DataFrame(cm, index=labels, columns=labels)
+
+    return metrics, pd.DataFrame(report).transpose(), cm_df
 
 
 if __name__ == "__main__":
     df = generate_dataset()
     df = assign_risk(df)
-    metrics, evaluation_df = train_knn(df)
+    metrics, evaluation_df, cm_df = train_knn(df)
     print(metrics)
     print(evaluation_df)
+    print(cm_df)

--- a/src/streamlit_app.py
+++ b/src/streamlit_app.py
@@ -1,4 +1,6 @@
 import streamlit as st
+import seaborn as sns
+import matplotlib.pyplot as plt
 from knn_risk_classifier import generate_dataset, assign_risk, train_knn
 
 
@@ -19,20 +21,26 @@ def main():
         "KNN Neighbors", min_value=1, max_value=20, value=3, step=1
     )
 
-    if st.sidebar.button("Run Classification"):
-        df = generate_dataset(
-            sc_increase_percentage=sc_increase,
-            qa_increase_percentage=qa_increase,
-            n_samples=int(n_samples),
-        )
-        df = assign_risk(df)
-        metrics, report = train_knn(df, n_neighbors=int(n_neighbors))
+    df = generate_dataset(
+        sc_increase_percentage=sc_increase,
+        qa_increase_percentage=qa_increase,
+        n_samples=int(n_samples),
+    )
+    df = assign_risk(df)
+    metrics, report, cm_df = train_knn(df, n_neighbors=int(n_neighbors))
 
-        st.subheader("Metrics")
-        st.json(metrics)
+    st.subheader("Metrics")
+    st.json(metrics)
 
-        st.subheader("Classification Report")
-        st.dataframe(report)
+    st.subheader("Classification Report")
+    st.dataframe(report)
+
+    st.subheader("Confusion Matrix")
+    fig, ax = plt.subplots()
+    sns.heatmap(cm_df, annot=True, fmt="d", cmap="Blues", ax=ax)
+    ax.set_xlabel("Predicted")
+    ax.set_ylabel("Actual")
+    st.pyplot(fig)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- display metrics, report and confusion matrix automatically in the Streamlit app
- return confusion matrix from `train_knn`
- print confusion matrix in module main section
- document automatic refresh and visualization in the README

## Testing
- `python -m py_compile src/knn_risk_classifier.py src/streamlit_app.py`

------
https://chatgpt.com/codex/tasks/task_e_6863dbd83e20832b8db4075c2a3f8ab3