### PR TITLE
Add interactive pairplot

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,5 +24,11 @@ streamlit run src/streamlit_app.py
 
 Use the sidebar to tweak dataset generation parameters and the number of
 neighbors used in the KNN classifier. Results are updated automatically when
-parameters change and a confusion matrix visualization is displayed alongside the
-metrics and classification report.
+parameters change. After the classification report, a live Seaborn pairplot of
+the predicted risk levels is displayed for interactive exploration.
+
+## Example Output
+
+Running the script prints evaluation metrics and a classification report to the
+console. The interactive Streamlit app shows a pairplot generated from the
+current settings directly in the browser.

--- a/src/knn_risk_classifier.py
+++ b/src/knn_risk_classifier.py
@@ -4,7 +4,14 @@ import random
 import seaborn as sns
 import matplotlib.pyplot as plt
 from sklearn.neighbors import KNeighborsClassifier
-from sklearn.metrics import accuracy_score, precision_score, recall_score, f1_score, classification_report, confusion_matrix
+from sklearn.metrics import (
+    accuracy_score,
+    precision_score,
+    recall_score,
+    f1_score,
+    classification_report,
+    confusion_matrix,
+)
 from sklearn.preprocessing import StandardScaler
 from sklearn.model_selection import train_test_split
 
@@ -101,13 +108,13 @@ def train_knn(df, n_neighbors=3):
     cm = confusion_matrix(y_test, y_pred, labels=labels)
     cm_df = pd.DataFrame(cm, index=labels, columns=labels)
 
-    return metrics, pd.DataFrame(report).transpose(), cm_df
+    return metrics, pd.DataFrame(report).transpose(), cm_df, knn, scaler
 
 
 if __name__ == "__main__":
     df = generate_dataset()
     df = assign_risk(df)
-    metrics, evaluation_df, cm_df = train_knn(df)
+    metrics, evaluation_df, cm_df, model, scaler = train_knn(df)
     print(metrics)
     print(evaluation_df)
     print(cm_df)

--- a/src/streamlit_app.py
+++ b/src/streamlit_app.py
@@ -27,7 +27,7 @@ def main():
         n_samples=int(n_samples),
     )
     df = assign_risk(df)
-    metrics, report, cm_df = train_knn(df, n_neighbors=int(n_neighbors))
+    metrics, report, cm_df, model, scaler = train_knn(df, n_neighbors=int(n_neighbors))
 
     st.subheader("Metrics")
     st.json(metrics)
@@ -35,12 +35,14 @@ def main():
     st.subheader("Classification Report")
     st.dataframe(report)
 
-    st.subheader("Confusion Matrix")
-    fig, ax = plt.subplots()
-    sns.heatmap(cm_df, annot=True, fmt="d", cmap="Blues", ax=ax)
-    ax.set_xlabel("Predicted")
-    ax.set_ylabel("Actual")
-    st.pyplot(fig)
+
+    st.subheader("Pairplot")
+    all_features = df.drop(columns=["Risk Classification"])
+    preds = model.predict(scaler.transform(all_features))
+    pairplot_df = all_features.copy()
+    pairplot_df["Predicted Risk"] = preds
+    g = sns.pairplot(pairplot_df, hue="Predicted Risk")
+    st.pyplot(g.fig)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- remove saved pairplot image
- show a live Seaborn pairplot in the Streamlit app below the report
- drop the confusion matrix from the app and update README accordingly

## Testing
- `pip install -r requirements.txt`
- `python src/knn_risk_classifier.py`


------
https://chatgpt.com/codex/tasks/task_e_6863df97c0ec832badfc230cce3e544a